### PR TITLE
Map `listeners` to inner component's `on` prop

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -32,9 +32,6 @@ import 'vuetify/dist/vuetify.min.css'
 
 Vue.use(Vuetify)
 
-
-Vue.use(Vuetify)
-
 // Override default command mount to use it with Vuetify
 Cypress.Commands.add("mount", (component, args = {}) => {
   const { listeners, ...props } = args

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -26,18 +26,34 @@
 
 import { mount } from "cypress/vue2";
 import Vue from 'vue'
-import Vuetify from 'vuetify/lib/framework'
 import { VApp } from 'vuetify/lib/components/VApp'
+import Vuetify from 'vuetify'
+import 'vuetify/dist/vuetify.min.css'
+
+Vue.use(Vuetify)
+
 
 Vue.use(Vuetify)
 
 // Override default command mount to use it with Vuetify
-Cypress.Commands.add("mount", (component, args) => {
-  return mount(
-    { render: (h) => h(VApp, [h(component, args)]) },
-    { vuetify: new Vuetify({}), ...args }
-  );
-});
+Cypress.Commands.add("mount", (component, args = {}) => {
+  const { listeners, ...props } = args
+
+  // pass event handlers to child component via `on` prop
+  const on = Object.entries(listeners || {}).reduce((acc, [event, handler]) => {
+    acc[event] = handler
+    return acc
+  }, {})
+
+  return mount({
+    vuetify: new Vuetify({}),
+    render: h => h(
+      VApp, [
+        h(component, { ...props, on })
+      ]
+    )
+  })
+})
 
 // Also add a command to use easily vue-test-utils as describe by Jessica Sachs
 // https://github.com/JessicaSachs/cypress-loves-vite/blob/develop/cypress/support/index.js#L19

--- a/src/components/test/Test.cy.js
+++ b/src/components/test/Test.cy.js
@@ -37,20 +37,8 @@ describe("<Test />", () => {
     });
 
     // Trigger emit event
-    cy.get("button").contains("Click Me").click();
-
-    // Assert event using  Cypress.vue.$on
-    cy.then(() => {
-      Cypress.vue.$on("click", onClickSpy);
+    cy.get("button").contains("Click Me").click().then(() => {
       expect(onClickSpy).to.be.calledOnce;
-    });
-
-    // Assert event using spies
-    cy.get("@onClickSpy").should("have.been.calledOnce");
-
-    // Assert event using listener from vue-test-utils
-    cy.vue().then((wrapper) => {
-      expect(wrapper.emitted("click")).to.have.length(1);
     });
   });
 });


### PR DESCRIPTION
Basically `<button @click="..." />` becomes `h('button', { on: { click: "..." })` after Vue compiles everything. I found it in the JSX docs: https://v2.vuejs.org/v2/guide/render-function.html#v-model. 

So to correctly pass the listeners from `listeners` to the `on` prop,  wrote a little utility function. There's a few ways to do things with the traditional Test Utils API and the Cypress API on top of it, we definitely need better docs and to standardise on one way to do things.

Hope this helps! Let me know if you have any other questions.